### PR TITLE
Bumb the internal version to 999

### DIFF
--- a/Loader.lua
+++ b/Loader.lua
@@ -15,7 +15,7 @@ local ldbi = LibStub("LibDBIcon-1.0")
 -- Generate our version variables
 --
 
-local BIGWIGS_VERSION = 8
+local BIGWIGS_VERSION = 999
 local BIGWIGS_RELEASE_STRING, BIGWIGS_VERSION_STRING = "", ""
 local versionQueryString, versionResponseString = "Q^%d^%s", "V^%d^%s"
 
@@ -25,28 +25,14 @@ do
 	local ALPHA = "ALPHA"
 	local RELEASE = "RELEASE"
 
-	local releaseType = RELEASE
 	local myGitHash = "@project-abbreviated-hash@" -- The ZIP packager will replace this with the Git hash.
-	local releaseString = ""
-	--@alpha@
-	-- The following code will only be present in alpha ZIPs.
-	releaseType = ALPHA
-	--@end-alpha@
 
 	-- If we find "@" then we're running from Git directly.
 	if myGitHash:find("@", nil, true) then
 		myGitHash = "repo"
-		releaseType = REPO
 	end
 
-	if releaseType == REPO then
-		releaseString = L.sourceCheckout:format(BIGWIGS_VERSION)
-	elseif releaseType == RELEASE then
-		releaseString = L.officialRelease:format(BIGWIGS_VERSION, myGitHash)
-	elseif releaseType == ALPHA then
-		releaseString = L.alphaRelease:format(BIGWIGS_VERSION, myGitHash)
-	end
-	BIGWIGS_RELEASE_STRING = releaseString
+	BIGWIGS_RELEASE_STRING = "You are running the Ascendance release of BigWigs"
 	BIGWIGS_VERSION_STRING = ("%d-%s"):format(BIGWIGS_VERSION, myGitHash)
 	-- Format is "V:version-hash"
 	versionQueryString = versionQueryString:format(BIGWIGS_VERSION, myGitHash)


### PR DESCRIPTION
To avoid members getting constant warnings about being out of date bump the internal BigWigs version to 999, and provide a custom release string.